### PR TITLE
chore: add release workflow for pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        run: |
+          pipx install poetry
+
+      - name: Build artifacts
+        run: |
+          poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true

--- a/docs/automation-roadmap.md
+++ b/docs/automation-roadmap.md
@@ -7,7 +7,7 @@
    - Owner: `kakashysen`
    - Repository: `kakashysen/ios-simulator-cleaner`
    - Workflow: `.github/workflows/release.yml`
-3. Add a `release.yml` workflow that triggers on tags, builds with `poetry build`, and runs `pypa/gh-action-pypi-publish@release/v1`.
+3. Configure the existing `.github/workflows/release.yml` workflow (added in v0.1.0+) to use the trusted publisher once PyPI authorisation is in place.
 
 ## Tap Auto-bump
 


### PR DESCRIPTION
## Summary
- add trusted-publisher release workflow for PyPI
- document how to connect workflow to PyPI configuration

## Testing
- not run (CI workflow addition only)
